### PR TITLE
Add an option to the resource monitors to specify "free" memory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@
 * Corrected scaling of volume plugin for HiDPI monitors.
 * Fixed connection name dropdown list in netstatus plugin.
 * Added option to battery monitor to hide number of battery in tooltip.
+* Added option to resource monitors to show cached and buffered memory as
+    used.
 
 0.10.0
 -------------------------------------------------------------------------

--- a/plugins/monitors/monitors.c
+++ b/plugins/monitors/monitors.c
@@ -13,6 +13,7 @@
  *               2015 Rafał Mużyło <galtgendo@gmail.com>
  *               2018 Mamoru TASAKA <mtasaka@fedoraproject.org>
  *               2019 Carles Pina i Estany <carles@pina.cat>
+ *               2020 Ingo Brückl
  *
  * <terms>
  * Copyright (c) 2008-2014 LxDE Developers, see the file AUTHORS for details.
@@ -108,6 +109,7 @@ struct Monitor {
     gint         pixmap_height;     /* Does not include border size           */
     stats_set    *stats;            /* Circular buffer of values              */
     stats_set    total;             /* Maximum possible value, as in mem_total*/
+    int          *maxfree;          /* Count buffers & cache as free memory   */
     gint         ring_cursor;       /* Cursor for ring/circular buffer        */
     gchar        *color;            /* Color of the graph                     */
     gboolean     (*update) (struct Monitor *); /* Update function             */
@@ -133,6 +135,7 @@ typedef struct {
     config_setting_t *settings;
     Monitor  *monitors[N_MONITORS];          /* Monitors                      */
     int      displayed_monitors[N_MONITORS]; /* Booleans                      */
+    int      show_cached_as_free;            /* What memory is shown as used  */
     char     *action;                        /* What to do on click           */
     guint    timer;                          /* Timer for regular updates     */
 } MonitorsPlugin;
@@ -189,6 +192,8 @@ monitor_init(MonitorsPlugin *mp, Monitor *m, gchar *color)
     g_signal_connect (G_OBJECT(m->da), "draw",
         G_CALLBACK(draw), (gpointer) m);
 #endif
+
+    m->maxfree = &mp->show_cached_as_free;
 
     return m;
 }
@@ -363,8 +368,10 @@ mem_update(Monitor * m)
      * 'man free' doesn't specify this)
      * 'mem_cached' definitely counts as 'free' because it is immediately
      * released should any application need it. */
-    m->stats[m->ring_cursor] = (mem_total - mem_buffers - mem_free -
-            mem_cached - mem_sreclaimable) / (float)mem_total;
+    m->stats[m->ring_cursor] = mem_total - mem_free;
+    if (*m->maxfree)
+        m->stats[m->ring_cursor] -= mem_buffers + mem_cached + mem_sreclaimable;
+    m->stats[m->ring_cursor] /= (float)mem_total;
 
     m->ring_cursor++;
     if (m->ring_cursor >= m->pixmap_width)
@@ -659,11 +666,16 @@ monitors_constructor(LXPanel *panel, config_setting_t *settings)
     /* First time we use this plugin : only display CPU usage */
     mp->displayed_monitors[CPU_POSITION] = 1;
 
+    /* Default is: memory used by cache is free */
+    mp->show_cached_as_free = 1;
+
     /* Apply options */
     config_setting_lookup_int(settings, "DisplayCPU",
                               &mp->displayed_monitors[CPU_POSITION]);
     config_setting_lookup_int(settings, "DisplayRAM",
                               &mp->displayed_monitors[MEM_POSITION]);
+    config_setting_lookup_int(settings, "ShowCachedAsFree",
+                              &mp->show_cached_as_free);
     if (config_setting_lookup_string(settings, "Action", &tmp))
         mp->action = g_strdup(tmp);
     if (config_setting_lookup_string(settings, "CPUColor", &tmp))
@@ -735,6 +747,7 @@ monitors_config (LXPanel *panel, GtkWidget *p)
         _("CPU color"), &colors[CPU_POSITION], CONF_TYPE_STR,
         _("Display RAM usage"), &mp->displayed_monitors[1], CONF_TYPE_BOOL,
         _("RAM color"), &colors[MEM_POSITION], CONF_TYPE_STR,
+        _("Show memory used by cache as free"), &mp->show_cached_as_free, CONF_TYPE_BOOL,
         _("Action when clicked (default: lxtask)"), &mp->action, CONF_TYPE_STR,
         NULL);
 
@@ -805,6 +818,7 @@ start:
     }
     config_group_set_int(mp->settings, "DisplayCPU", mp->displayed_monitors[CPU_POSITION]);
     config_group_set_int(mp->settings, "DisplayRAM", mp->displayed_monitors[MEM_POSITION]);
+    config_group_set_int(mp->settings, "ShowCachedAsFree", mp->show_cached_as_free);
     config_group_set_string(mp->settings, "Action", mp->action);
     config_group_set_string(mp->settings, "CPUColor",
                             mp->monitors[CPU_POSITION] ? colors[CPU_POSITION] : NULL);


### PR DESCRIPTION
Memory used by kernel buffers, page caches, etc. is usually considered
to be "free", but it may be useful to count this memory as being used.

The user can now choose whether such memory should be shown as free
memory.