### PR TITLE
Fix connection name dropdown list in netstatus plugin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 * Fixed battery alarm when measurement of current is missing.
 * Fixed spelling errors on "allow to" in plugins descriptions, and "GTK2+" to
     more correct "GTK+".
+* Fixed connection name dropdown list in netstatus plugin.
 
 0.10.0
 -------------------------------------------------------------------------

--- a/plugins/netstatus/netstatus-iface.c
+++ b/plugins/netstatus/netstatus-iface.c
@@ -1122,12 +1122,6 @@ netstatus_iface_get_device_details (NetstatusIface  *iface,
   return TRUE;
 }
 
-#if !defined(HAVE_SOCKADDR_SA_LEN)
-#define NETSTATUS_SA_LEN(saddr) (sizeof (struct sockaddr))
-#else
-#define NETSTATUS_SA_LEN(saddr) (MAX ((saddr)->sa_len, sizeof (struct sockaddr)))
-#endif /* HAVE_SOCKADDR_SA_LEN */
-
 /* Taken From R. Stevens Unix Network Programming Vol. 1.
  *
  * SIOCGIFCONF does not return an error on all systems if
@@ -1221,7 +1215,7 @@ netstatus_list_interface_names (GError **error)
       struct ifreq *if_req = (struct ifreq *) p;
       gboolean      loopback = FALSE;
 
-      p += sizeof (if_req->ifr_name) + NETSTATUS_SA_LEN (&if_req->ifr_addr);
+      p = (char *) (if_req + 1);
 
       if (ioctl (fd, SIOCGIFFLAGS, if_req) < 0)
 	{


### PR DESCRIPTION
The list of connection names contained nothing more than
the loopback interface (lo) and an empty entry so far.
This was due to the loop variable being incremented incorrectly.

Since the variable points to the beginning of an ifreq structure,
it can easily be incremented by simple pointer addition.