### PR TITLE
Show the dialog icon after the window has been presented

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
     used.
 * Improved translations and design fix of ALSA volume control popup.
 * Made netstatus_icon_set_tooltips_enabled() work.
+* Fixed a sometimes incorrectly placed icon in the netstatus plugin.
 
 0.10.0
 -------------------------------------------------------------------------

--- a/plugins/netstatus/netstatus-dialog.c
+++ b/plugins/netstatus/netstatus-dialog.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2003 Sun Microsystems, Inc.
  * Copyright (C) 2004 Red Hat Inc.
+ * Copyright (C) 2020 Ingo Brückl
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -629,7 +630,6 @@ netstatus_dialog_setup_connection (NetstatusDialogData *data)
   netstatus_icon_set_tooltips_enabled (NETSTATUS_ICON (icon), FALSE);
   netstatus_icon_set_show_signal (NETSTATUS_ICON (icon), FALSE);
   gtk_box_pack_end (GTK_BOX (hbox), icon, FALSE, TRUE, 4);
-  gtk_widget_show (icon);
 
   data->icon = NETSTATUS_ICON (icon);
 
@@ -872,4 +872,13 @@ const char* netstatus_dialog_get_iface_name( GtkWidget* dialog )
     NetstatusDialogData *data;
     data = g_object_get_data (G_OBJECT (dialog), "netstatus-dialog-data");
     return netstatus_iface_get_name (data->iface);
+}
+
+void netstatus_dialog_present (GtkWidget *dialog)
+{
+    NetstatusDialogData *data;
+
+    data = g_object_get_data(G_OBJECT(dialog), "netstatus-dialog-data");
+    gtk_window_present(GTK_WINDOW(dialog));
+    gtk_widget_show(data->icon);
 }

--- a/plugins/netstatus/netstatus-dialog.h
+++ b/plugins/netstatus/netstatus-dialog.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2003 Sun Microsystems, Inc.
+ * Copyright (C) 2020 Ingo Brückl
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -37,6 +38,8 @@ const char* netstatus_dialog_get_configuration_tool( GtkWidget* dialog );
 
 /* 2009.05.10 Add by Hong Jen Yee (PCMan) to be used in lxpanel plugin */
 const char* netstatus_dialog_get_iface_name( GtkWidget* dialog );
+
+void netstatus_dialog_present(GtkWidget *dialog);
 
 G_END_DECLS
 

--- a/plugins/netstatus/netstatus.c
+++ b/plugins/netstatus/netstatus.c
@@ -3,6 +3,7 @@
  *               2008 Fred Chien <fred@lxde.org>
  *               2009 martyj19 <martyj19@comcast.net>
  *               2014 Andriy Grytsenko <andrej@rep.kiev.ua>
+ *               2020 Ingo Brückl
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -99,7 +100,7 @@ static gboolean on_button_press( GtkWidget* widget, GdkEventButton* evt, LXPanel
             netstatus_dialog_set_configuration_tool( ns->dlg, ns->config_tool );
             g_signal_connect( ns->dlg, "response", G_CALLBACK(on_response), ns );
         }
-        gtk_window_present( GTK_WINDOW(ns->dlg) );
+        netstatus_dialog_present(ns->dlg);
     }
     return TRUE;
 }


### PR DESCRIPTION
This fixes a bug that sometimes made the icon not appear where
it was supposed to, but in the upper left corner of the dialog
above the tab.