### PR TITLE
Remove unneeded gdk-pixbuf-xlib.h inclusions

### DIFF
--- a/plugins/launchtaskbar.c
+++ b/plugins/launchtaskbar.c
@@ -68,7 +68,6 @@
 #include <X11/Xutil.h>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk-pixbuf-xlib/gdk-pixbuf-xlib.h>
 #include <gdk/gdk.h>
 #include <glib/gi18n.h>
 

--- a/plugins/task-button.c
+++ b/plugins/task-button.c
@@ -43,7 +43,6 @@
 #include <X11/Xutil.h>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk-pixbuf-xlib/gdk-pixbuf-xlib.h>
 #include <gdk/gdk.h>
 #include <glib/gi18n.h>
 #include <cairo-xlib.h>

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -29,7 +29,6 @@
 #include "private.h"
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk-pixbuf-xlib/gdk-pixbuf-xlib.h>
 #include <gdk/gdk.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
gdk-pixbuf-xlib was removed from gdk-pixbuf in version 2.42.0.

Bug: https://bugs.gentoo.org/753923