### PR TITLE
Correct panel size under GTK3. Fixes Sourceforge #773.

### DIFF
--- a/src/panel.c
+++ b/src/panel.c
@@ -293,6 +293,12 @@ lxpanel_get_preferred_height (GtkWidget *widget,
   if (natural_height)
       *natural_height = requisition.height;
 }
+
+static GtkSizeRequestMode
+lxpanel_get_request_mode (GtkWidget *widget)
+{
+    return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+}
 #endif
 
 static void lxpanel_size_allocate(GtkWidget *widget, GtkAllocation *a)
@@ -413,6 +419,7 @@ static void lxpanel_class_init(PanelToplevelClass *klass)
 #if GTK_CHECK_VERSION(3, 0, 0)
     widget_class->get_preferred_width = lxpanel_get_preferred_width;
     widget_class->get_preferred_height = lxpanel_get_preferred_height;
+    widget_class->get_request_mode = lxpanel_get_request_mode;
 #else
     widget_class->size_request = lxpanel_size_request;
 #endif


### PR DESCRIPTION
This fixes the dreaded "right hand of lxpanel missing".

https://www.reddit.com/r/voidlinux/comments/d4fgrl/lxpanel_is_not/

https://sourceforge.net/p/lxde/bugs/773/
