### PR TITLE
Correct icon-grid width under GTK3. Fixes Github #29.

### DIFF
--- a/src/icon-grid.c
+++ b/src/icon-grid.c
@@ -392,7 +392,7 @@ static void panel_icon_grid_get_preferred_width(GtkWidget *widget,
     }
     panel_icon_grid_size_request(widget, &requisition);
     if (minimal_width)
-        *minimal_width = requisition.width;
+        *minimal_width = ig->constrain_width ? 0 : requisition.width;
     if (natural_width)
         *natural_width = requisition.width;
 }


### PR DESCRIPTION
This fixes the "task icons don't rescale with GTK3" bug.

