### PR TITLE
Use XkbRF_GetNamesProp instead of xkb_symbols. Fixes #51

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,12 @@ AC_SUBST(LIBXML2_CFLAGS)
 AC_SUBST(LIBXML2_LIBS)
 fi
 
+# xkb
+if test x"$plugin_xkb" != "x"; then
+PKG_CHECK_MODULES([XKB], [xkbfile])
+AC_SUBST(XKB_LIBS)
+fi
+
 # Checks for header files.
 AC_PATH_X
 AC_HEADER_STDC

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -163,7 +163,9 @@ xkb_la_CFLAGS = \
 xkb_la_SOURCES = \
 	xkb/xkb-plugin.c \
 	xkb/xkb.c
-xkb_la_LIBADD = $(X11_LIBS)
+xkb_la_LIBADD = \
+	$(X11_LIBS) \
+	$(XKB_LIBS)
 
 xkeyboardconfigdir=$(datadir)/lxpanel/xkeyboardconfig
 xkeyboardconfig_DATA = \


### PR DESCRIPTION
Trying to parse xkb_symbols to get the currently active layouts is buggy and unreliable. This uses XkbRF_GetNamesProp() from X11/extensions/XKBrules.h instead.