### PR TITLE
Handle "Not Charging" state in battery indicator

### DIFF
--- a/plugins/batt/batt_sys.c
+++ b/plugins/batt/batt_sys.c
@@ -396,6 +396,7 @@ gboolean battery_is_charging( battery *b )
     return ( strcasecmp( b->state, "Unknown" ) == 0
             || strcasecmp( b->state, "Full" ) == 0
             || strcasecmp( b->state, "Charging" ) == 0
+            || strcasecmp( b->state, "Not Charging" ) == 0
             || b->current_now == 0 ); /* bug sf.net, #720 */
 }
 


### PR DESCRIPTION
When the battery is has reached the target charge level, some devices use the status "Not Charging". LXpanel should not interpret this to mean "Discharging", but rather the same as "Full".