### PR TITLE
fix cpufreq applet

### DIFF
--- a/plugins/cpufreq/cpufreq.c
+++ b/plugins/cpufreq/cpufreq.c
@@ -162,8 +162,12 @@ set_gov(const char* cpu, const char* val) {
 
 static void
 cpufreq_set_freq(GtkWidget *widget, Param* p){
+    GList *curr;
+
     if(strcmp(p->cf->cur_governor, "userspace")) return;
-    set_freq(p->cf->cpus->data, p->data);
+
+    for(curr = p->cf->cpus; curr; curr = curr->next)
+        set_freq(curr->data, p->data);
 }
 
 static GtkWidget *
@@ -245,7 +249,10 @@ get_cpus(cpufreq *cf)
 
 static void
 cpufreq_set_governor(GtkWidget *widget, Param* p){
-    set_gov(p->cf->cpus->data, p->data);
+    GList *curr;
+
+    for(curr = p->cf->cpus; curr; curr = curr->next)
+        set_gov(curr->data, p->data);
 }
 
 static GtkWidget *

--- a/plugins/cpufreq/cpufreq.c
+++ b/plugins/cpufreq/cpufreq.c
@@ -170,6 +170,14 @@ cpufreq_set_freq(GtkWidget *widget, Param* p){
         set_freq(curr->data, p->data);
 }
 
+static void
+cpufreq_set_governor(GtkWidget *widget, Param* p) {
+    GList *curr;
+
+    for(curr = p->cf->cpus; curr; curr = curr->next)
+        set_gov(curr->data, p->data);
+}
+
 static GtkWidget *
 frequency_menu(cpufreq *cf){
     FILE *fp;
@@ -245,14 +253,6 @@ get_cpus(cpufreq *cf)
         }
     }
     g_dir_close(cpuDirectory);
-}
-
-static void
-cpufreq_set_governor(GtkWidget *widget, Param* p){
-    GList *curr;
-
-    for(curr = p->cf->cpus; curr; curr = curr->next)
-        set_gov(curr->data, p->data);
 }
 
 static GtkWidget *

--- a/plugins/cpufreq/cpufreq.c
+++ b/plugins/cpufreq/cpufreq.c
@@ -99,7 +99,7 @@ get_cur_freq(cpufreq *cf){
     }
 }
 
-/*static void
+static void
 get_governors(cpufreq *cf){
     FILE *fp;
     GList *l;
@@ -189,7 +189,7 @@ frequency_menu(cpufreq *cf){
 
     fclose(fp);
     return GTK_WIDGET(menu);
-}*/
+}
 
 static void
 get_cpus(cpufreq *cf)
@@ -228,7 +228,7 @@ get_cpus(cpufreq *cf)
     g_dir_close(cpuDirectory);
 }
 
-/*static void
+static void
 cpufreq_set_governor(GtkWidget *widget, Param* p){
     FILE *fp;
     char buf[ 100 ], sstmp [ 256 ];
@@ -291,7 +291,7 @@ cpufreq_menu(cpufreq *cf){
     }
 
     return GTK_WIDGET (menu);
-}*/
+}
 
 
 
@@ -303,9 +303,9 @@ clicked(GtkWidget *widget, GdkEventButton *evt, LXPanel *panel)
     /* Standard right-click handling. */
     if( evt->button == 1 )
     {
-// Setting governor can't work without root privilege
-//      gtk_menu_popup( cpufreq_menu((cpufreq*)plugin->priv), NULL, NULL, NULL, NULL,
-//                      evt->button, evt->time );
+      cpufreq *cf = lxpanel_plugin_get_data(widget);
+      gtk_menu_popup( GTK_MENU(cpufreq_menu(cf)), NULL, NULL, NULL, NULL,
+                      evt->button, evt->time );
       return TRUE;
     }
 

--- a/plugins/cpufreq/cpufreq.c
+++ b/plugins/cpufreq/cpufreq.c
@@ -138,17 +138,32 @@ get_governors(cpufreq *cf){
 }
 
 static void
-cpufreq_set_freq(GtkWidget *widget, Param* p){
+set_file(const char* cpu, const char* val, const char* file) {
     FILE *fp;
-    char buf[ 100 ], sstmp [ 256 ];
+    char path [ 256 ];
 
-    if(strcmp(p->cf->cur_governor, "userspace")) return;
+    snprintf(path, sizeof(path), "%s/%s", cpu, file);
 
-    sprintf(sstmp,"%s/%s",p->cf->cpus->data, SCALING_SETFREQ);
-    if ((fp = fopen( sstmp, "w")) != NULL) {
-        fprintf(fp,"%s",p->data);
+    if ((fp = fopen( path, "w")) != NULL) {
+        fprintf(fp,"%s",val);
         fclose(fp);
     }
+}
+
+static void
+set_freq(const char* cpu, const char* val) {
+    set_file(cpu, val, SCALING_SETFREQ);
+}
+
+static void
+set_gov(const char* cpu, const char* val) {
+    set_file(cpu, val, SCALING_GOV);
+}
+
+static void
+cpufreq_set_freq(GtkWidget *widget, Param* p){
+    if(strcmp(p->cf->cur_governor, "userspace")) return;
+    set_freq(p->cf->cpus->data, p->data);
 }
 
 static GtkWidget *
@@ -230,14 +245,7 @@ get_cpus(cpufreq *cf)
 
 static void
 cpufreq_set_governor(GtkWidget *widget, Param* p){
-    FILE *fp;
-    char buf[ 100 ], sstmp [ 256 ];
-
-    sprintf(sstmp, "%s/%s", p->cf->cpus->data, SCALING_GOV);
-    if ((fp = fopen( sstmp, "w")) != NULL) {
-        fprintf(fp,"%s",p->data);
-        fclose(fp);
-    }
+    set_gov(p->cf->cpus->data, p->data);
 }
 
 static GtkWidget *


### PR DESCRIPTION
i submitted this fix on the sourceforge.net tracker several years ago, and have used it ever since - it works splendidly.

in order to be able to use it, the user has to have the proper permissions, which i achieve with a startup script doing this:

        for i in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_setspeed ; do
                chown root:cpufreq "$i"
                chmod 664 "$i"
        done

and having my user added to the cpufreq group.