### PR TITLE
Check whether desktop is shown using _NET_SHOWING_DESKTOP X11 Extende…

### DIFF
--- a/plugins/wincmd.c
+++ b/plugins/wincmd.c
@@ -136,6 +136,9 @@ static gboolean wincmd_button_clicked(GtkWidget * widget, GdkEventButton * event
          * Otherwise, fall back to iconifying windows individually. */
         if (gdk_x11_screen_supports_net_wm_hint(screen, atom))
         {
+
+	    wc->toggle_state = get_net_showing_desktop();
+		
             int showing_desktop = ((( ! wc->toggle_preference) || ( ! wc->toggle_state)) ? 1 : 0);
             Xclimsgx(xscreen, RootWindowOfScreen(xscreen),
                     a_NET_SHOWING_DESKTOP, showing_desktop, 0, 0, 0, 0);

--- a/src/misc.c
+++ b/src/misc.c
@@ -649,6 +649,24 @@ get_net_number_of_desktops()
     RET(desknum);
 }
 
+int get_net_showing_desktop(){
+
+    // 1 means Window Manager is in "showing the desktop" mode
+    int is_currently_showing_desktop = 0;
+    gulong *data = NULL;
+    int nitems = 0;
+
+    ENTER;
+    data = get_xaproperty (GDK_ROOT_WINDOW(), a_NET_SHOWING_DESKTOP , XA_CARDINAL, &nitems);
+    if (data) {
+        is_currently_showing_desktop = *data;
+        XFree (data);
+        data = NULL;
+    }
+    else{
+    }
+    RET(is_currently_showing_desktop);
+}
 
 int
 get_net_current_desktop ()


### PR DESCRIPTION
…d Window Manager Hints property.

To correctly reflect the desktop showing state in the UI, the current state needs to be read from X11 properties set by the window manager. Otherwise the UI may not always be updated when desktop showing state is changed by other applications.