### PR TITLE
Fix variable to get widget settings

### DIFF
--- a/plugins/launchtaskbar.c
+++ b/plugins/launchtaskbar.c
@@ -962,7 +962,7 @@ static void on_gtk_cursor_blink_time_changed(GObject *gsettings, GParamSpec *psp
     if (tb->flash_timeout == 0) /* nothing to do? */
         return;
     g_source_remove(tb->flash_timeout);
-    g_object_get(gtk_widget_get_settings(GTK_WIDGET(tb)), "gtk-cursor-blink-time",
+    g_object_get(gtk_widget_get_settings(GTK_WIDGET(tb->plugin)), "gtk-cursor-blink-time",
                  &interval, NULL);
     tb->flash_timeout = g_timeout_add(interval / 2, flash_window_timeout, tb);
 }


### PR DESCRIPTION
This caused the panel to freeze when the cursor blink time was changed.

The console output was:
```
(lxpanel:57939): Gtk-CRITICAL **: 20:17:59.216: gtk_widget_get_settings: assertion 'GTK_IS_WIDGET (widget)' failed

(lxpanel:57939): GLib-GObject-CRITICAL **: 20:17:59.216: g_object_get: assertion 'G_IS_OBJECT (object)' failed
```